### PR TITLE
Use obs_source_properties instead of obs_get_source_properties

### DIFF
--- a/source/handlers/handler-obs-source.cpp
+++ b/source/handlers/handler-obs-source.cpp
@@ -1484,7 +1484,7 @@ void streamdeck::handlers::obs_source::properties(std::shared_ptr<streamdeck::js
 	}
 
 	// Convert properties into useful JSON objects.
-	std::shared_ptr<obs_properties_t> properties{obs_get_source_properties(obs_source_get_id(source.get())),
+	std::shared_ptr<obs_properties_t> properties{obs_source_properties(source.get()),
 												 [](obs_properties_t* v) { obs_properties_destroy(v); }};
 	res->set_result(build_properties_metadata(properties.get()));
 }


### PR DESCRIPTION
it is faster and has less chance of null reference error in the `get_properties` function of the source, because `void* data` is not `null`
Also some source have different properties based on changes in the settings or the state of the source.